### PR TITLE
Handle the error from the agent update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
   file: "./bin/$BINARY_FILE_NAME"
   skip_cleanup: true
   file_glob: "true"
-  name: "$BINARY_FILE_NAME-$TRAVIS_TAG"
+  name: "$BINARY_FILE_NAME_$TRAVIS_TAG"
   on:
     branch: "master"
     tags: true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This is a projects that lets you check for outdated ecs agents in AWS and is wri
 
 ## TODO
 
-- Set auto update of the agent.
 - Introduce other methods of notification.
 
 ## Getting Started
@@ -43,7 +42,7 @@ In order to compile and run the go binary you only need to execute docker-compos
 ```
 docker-compose up --build
 ```
-Which will put the binary inside the ./bin folder which can be run on linux systems and can be used as an artiact for deployment.
+Which will put the binary inside the ./bin folder which can be run on linux systems and can be used as an artifact for deployment.
 
 Running the binary is as simple as doing:
 ```

--- a/src/main.go
+++ b/src/main.go
@@ -37,8 +37,8 @@ func execute(cluster_instances map[string][]string, s *session.Session) []string
 		if os.Getenv("UPDATE_ECS_AGENT") == "true" {
 
 			fmt.Println("Updating ecs agents on all instances for cluster:", key)
-			instance_id := update_ecs_agent(s, key, value)
-			fmt.Println("Updated instance", instance_id)
+			agent_update_response := update_ecs_agent(s, key, value)
+			fmt.Println(agent_update_response)
 		}
 	}
 	return slack_http_statuses
@@ -56,10 +56,10 @@ func update_ecs_agent(s *session.Session, cluster string, container_instances []
 		result, err := svc.UpdateContainerAgent(input)
 
 		if err != nil {
-			fmt.Println(err.Error())
+			return_value = fmt.Sprintf("Instance couldn't not be updated, the error is %s", err.Error())
+		} else {
+			return_value = fmt.Sprintf("Instance %s successfully updated", *result.ContainerInstance.Ec2InstanceId)
 		}
-
-		return_value = *result.ContainerInstance.Ec2InstanceId
 
 	}
 	return return_value


### PR DESCRIPTION
- do not exit with an error and instaead log it to stdout when the agent cannot be updated. Possible reasons are:
  - not using aws linux
- update the readme
- rename the binary